### PR TITLE
Missing parameter in declaration of MapType

### DIFF
--- a/src/map.h
+++ b/src/map.h
@@ -14,7 +14,7 @@
 #include <nan.h>
 #include "v8_value_hasher.h"
 
-typedef unordered_map<CopyablePersistent *, CopyablePersistent *, v8_value_hash> MapType;
+typedef unordered_map<CopyablePersistent *, CopyablePersistent *, v8_value_hash, v8_value_equal_to> MapType;
 
 class NodeMap : public Nan::ObjectWrap {
 public:


### PR DESCRIPTION
the matcher fonction was missing in the declaration, preventing any match by the get and has fonction.
#5
